### PR TITLE
Use makeStyles build-in fluentui function instead inline element styles

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,8 @@ import {
     TableRow,
     webDarkTheme,
     webLightTheme,
+    makeStyles,
+    tokens,
     type Theme,
 } from "@fluentui/react-components";
 import { useEffect, useState } from "react";
@@ -18,6 +20,27 @@ import { Header } from "./Header";
 import { Header2 } from "./Header2";
 import { Mails } from "./Mails";
 import { Sidebar } from "./Sidebar";
+
+const useStyles = makeStyles({
+    root: {
+      backgroundColor: tokens.colorNeutralBackground1,
+      height: "100vh"
+    },
+    layout: {
+        height: "100%",
+        display: "flex",
+        flexDirection: "row",
+        boxSizing: "border-box",
+    },
+    container: {
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        gap: "20px",
+        padding: "20px",
+        boxSizing: "border-box",
+    }
+});
 
 const shouldUseDarkColors = (): boolean =>
     window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -28,6 +51,9 @@ export const App = () => {
     const [theme, setTheme] = useState<Theme>(getTheme());
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
+    // Get styles for Fluent UI components using makeStyles function.
+    const styles = useStyles();
+
     useEffect(() => {
         setTimeout(() => {
             setIsLoading(false);
@@ -37,26 +63,10 @@ export const App = () => {
     }, []);
 
     return (
-        <FluentProvider theme={theme} style={{ height: "100vh", background: "transparent" }}>
-            <div
-                style={{
-                    height: "100%",
-                    display: "flex",
-                    flexDirection: "row",
-                    boxSizing: "border-box",
-                }}
-            >
-                <Sidebar theme={theme} />
-                <div
-                    style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        width: "100%",
-                        gap: 20,
-                        padding: 20,
-                        boxSizing: "border-box",
-                    }}
-                >
+        <FluentProvider theme={theme} className={styles.root}>
+            <div className={styles.layout}>
+                <Sidebar />
+                <div className={styles.container}>
                     <Header />
                     <Header2 />
                     <div style={{ flexGrow: 1 }}>

--- a/src/renderer/Header.tsx
+++ b/src/renderer/Header.tsx
@@ -1,18 +1,23 @@
-import { Avatar, Input, Text } from "@fluentui/react-components";
+import { Avatar, Input, Text, makeStyles } from "@fluentui/react-components";
 import { SearchRegular } from "@fluentui/react-icons";
 
+const useStyles = makeStyles({
+    header: {
+        width: "100%",
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        gap: "20px",
+    }
+});
+
 export const Header = () => {
+    // Get styles for Fluent UI components using makeStyles function.
+    const styles = useStyles();
+
     return (
-        <div
-            style={{
-                width: "100%",
-                display: "flex",
-                flexDirection: "row",
-                justifyContent: "space-between",
-                alignItems: "center",
-                gap: 20,
-            }}
-        >
+        <div className={styles.header}>
             <div style={{ flexGrow: 1, display: "flex", flexDirection: "column" }}>
                 <Input
                     autoFocus

--- a/src/renderer/Header2.tsx
+++ b/src/renderer/Header2.tsx
@@ -1,15 +1,20 @@
-import { Radio, RadioGroup, Text } from "@fluentui/react-components";
+import { Radio, RadioGroup, Text, makeStyles } from "@fluentui/react-components";
+
+const useStyles = makeStyles({
+    subheader: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+    }
+});
 
 export const Header2 = () => {
+    // Get styles for Fluent UI components using makeStyles function.
+    const styles = useStyles();
+
     return (
-        <div
-            style={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                justifyContent: "space-between",
-            }}
-        >
+        <div className={styles.subheader}>
             <Text>Inbox</Text>
             <RadioGroup layout="horizontal" defaultValue="all">
                 <Radio value="all" label="All" />

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Button, ProgressBar, Tab, TabList, Text, type Theme } from "@fluentui/react-components";
+import { Button, ProgressBar, Tab, TabList, Text, makeStyles, tokens } from "@fluentui/react-components";
 import {
     AddRegular,
     ArchiveRegular,
@@ -10,23 +10,28 @@ import {
     StarRegular,
 } from "@fluentui/react-icons";
 
-export const Sidebar = ({ theme }: { theme: Theme }) => {
+const useStyles = makeStyles({
+    sidebar: {
+        height: "100%",
+        width: "200px",
+        display: "flex",
+        flexDirection: "column",
+        borderRightWidth: "1px",
+        borderRightColor: tokens.colorNeutralStroke3,
+        borderRightStyle: "solid",
+        gap: "10px",
+        padding: "20px",
+        boxSizing: "border-box",
+        flexShrink: 0,
+    }
+});
+
+export const Sidebar = () => {
+    // Get styles for Fluent UI components using makeStyles function.
+    const styles = useStyles();
+
     return (
-        <div
-            style={{
-                height: "100%",
-                width: 200,
-                display: "flex",
-                flexDirection: "column",
-                borderRightWidth: 1,
-                borderRightColor: theme.colorNeutralStroke3,
-                borderRightStyle: "solid",
-                gap: 10,
-                padding: 20,
-                boxSizing: "border-box",
-                flexShrink: 0,
-            }}
-        >
+        <div className={styles.sidebar}>
             <Button icon={<AddRegular />}>New message</Button>
             <div style={{ flexGrow: 1 }}>
                 <TabList vertical defaultSelectedValue="tab1" appearance="subtle">


### PR DESCRIPTION
First of all, thanks for your work!
Let's use build-in fluentui function makeStyles to style components. 
This allows us not to pass the current theme down to nested elements 